### PR TITLE
Performance Issue Resolution

### DIFF
--- a/RelationExtractor/pom.xml
+++ b/RelationExtractor/pom.xml
@@ -67,12 +67,12 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>3.8.1</version>
+            <version>3.25.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.8.1</version>
+            <version>3.25.1</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jdt</groupId>

--- a/RelationExtractor/src/main/java/FilePathOrganizer.java
+++ b/RelationExtractor/src/main/java/FilePathOrganizer.java
@@ -6,8 +6,8 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.stream.Stream;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 
 import org.apache.commons.io.FilenameUtils;
@@ -28,7 +28,7 @@ public class FilePathOrganizer {
                                                 .equals("java"))) {
                             javaFileStream.forEach(javaFile -> {
                                 try {
-                                    CompilationUnit cu = JavaParser.parse(javaFile);
+                                    CompilationUnit cu = StaticJavaParser.parse(javaFile);
                                     String filePathInPackage;
                                     if (cu.getPackageDeclaration().isPresent()) {
                                         filePathInPackage = cu.getPackageDeclaration().get().getNameAsString().replace(

--- a/RelationExtractor/src/main/java/Main.java
+++ b/RelationExtractor/src/main/java/Main.java
@@ -178,11 +178,8 @@ public class Main {
             });
         }
 
-        long time = System.nanoTime() - start;
-        int hour = (int) (time / 3600000000000L);
-        int minute = (int) ((time - (long) hour * 3600000000000L) / 60000000000L);
-        int second = (int) ((time - (long) hour * 3600000000000L) - (long) minute * 60000000000L / 1000000000L);
-        System.out.println("parse & resolve time : " + hour + "時間" + minute + "分" + second + "秒");
+        var duration = Duration.ofNanos(System.nanoTime() - start);
+        System.out.printf("parse & resolve time : %d:%02d:%02d\n", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart());
         System.out.println("totalResolveSuccess : " + totalResolveSuccess[0]);
         System.out.println("totalResolveFailed : " + totalResolveFailed[0]);
         System.out.println("FILE_NUM : " + FILE_NUM[0]);

--- a/RelationExtractor/src/main/java/Main.java
+++ b/RelationExtractor/src/main/java/Main.java
@@ -4,18 +4,21 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 
-import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseProblemException;
+import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
-import com.github.javaparser.symbolsolver.model.resolution.TypeSolver;
+import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import com.github.javaparser.utils.SourceRoot;
 import com.opencsv.CSVWriter;
 
 import org.apache.commons.io.FilenameUtils;
@@ -29,6 +32,8 @@ public class Main {
     final static long[] totalResolveFailed = { 0 };
     final static int[] resolveSuccess = { 0 };
     final static int[] resolveFailed = { 0 };
+
+    static boolean useSourceRoot = false;
 
     public static void main(String[] args) throws IOException, InterruptedException {
         Path dataRoot = Paths.get("data").toAbsolutePath().normalize();
@@ -76,50 +81,91 @@ public class Main {
                                 projectRootDir.toAbsolutePath().toFile());
                         // TypeSolver platform_framework_base = new JavaParserTypeSolver(
                         // new File(rawDataDir.getAbsolutePath() + "/platformframeworksbase"));
-                        reflectionTypeSolver.setParent(reflectionTypeSolver);
+                        //reflectionTypeSolver.setParent(reflectionTypeSolver);
                         CombinedTypeSolver combinedSolver = new CombinedTypeSolver();
                         combinedSolver.add(reflectionTypeSolver);
                         combinedSolver.add(javaParserTypeSolver);
                         // combinedSolver.add(platform_framework_base);
                         JavaSymbolSolver symbolSolver = new JavaSymbolSolver(combinedSolver);
-                        JavaParser.getStaticConfiguration().setSymbolResolver(symbolSolver);
 
-                        /*
-                         * 取得元ディレクトリからJavaファイルを再帰的に探索
-                         */
-                        try (Stream<Path> javaFileStream = Files.walk(projectRootDir)
-                                .filter(path -> Files.isRegularFile(path)
-                                        && FilenameUtils.getExtension(path.toAbsolutePath().toString())
-                                                .equals("java"));
-                                CSVWriter csvWriter = new CSVWriter(new FileWriter(csvPath.toFile()))) {
+                        if (useSourceRoot) {
+                            try (CSVWriter csvWriter = new CSVWriter(new FileWriter(csvPath.toFile()))) {
+                                SourceRoot sourceRoot = new SourceRoot(projectRootDir);
+                                sourceRoot.getParserConfiguration().setSymbolResolver(symbolSolver);
+                                var resultList = sourceRoot.tryToParseParallelized();
 
-                            javaFileStream.forEach(javaFile -> {
-                                FILE_NUM[0] += 1;
+                                for (var r : resultList) {
+                                    r.getResult().ifPresent(cu -> {
+                                        System.out.print(cu.getStorage().get().getPath().getFileName() + " \r");
+                                        Resolver resolver = new Resolver(true);
+                                        resolver.execute(cu);
+                                        resolveSuccess[0] += resolver.getResolveSuccess();
+                                        resolveFailed[0] += resolver.getResolveFailed();
 
-                                System.out.print("\r");
-                                System.out.print("Parsing : " + javaFile.getFileName());
-
-                                Resolver resolver = new Resolver(true);
-                                try {
-                                    CompilationUnit cu = JavaParser.parse(javaFile);
-                                    resolver.execute(cu);
-                                } catch (IOException e) {
-                                    throw new UncheckedIOException(e);
+                                        for (GraphEdge edge : resolver.getEdges()) {
+                                            String[] line = { edge.source().type(),
+                                                    edge.source().name(), edge.type(), edge.target().type(),
+                                                    edge.target().name() };
+                                            csvWriter.writeNext(line);
+                                        }
+                                    });
                                 }
-                                resolveSuccess[0] += resolver.getResolveSuccess();
-                                resolveFailed[0] += resolver.getResolveFailed();
+                            } catch (ParseProblemException e) {
+                                System.out.println("ParseProblemException : " + e.getMessage());
+                                return; // continue to next file
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            } finally {
+                                JavaParserFacade.clearInstances();
+                                System.gc();
+                            }
 
-                                for (GraphEdge edge : resolver.getEdges()) {
-                                    String[] line = { edge.source().type(),
-                                            edge.source().name(), edge.type(), edge.target().type(),
-                                            edge.target().name() };
-                                    csvWriter.writeNext(line);
-                                }
-                            });
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
+                        } else {
+                            StaticJavaParser.getParserConfiguration().setSymbolResolver(symbolSolver);
+
+                            /*
+                            * 取得元ディレクトリからJavaファイルを再帰的に探索
+                            */
+                            try (Stream<Path> javaFileStream = Files.walk(projectRootDir)
+                                    .filter(path -> Files.isRegularFile(path)
+                                            && FilenameUtils.getExtension(path.toAbsolutePath().toString())
+                                                    .equals("java"));
+                                    CSVWriter csvWriter = new CSVWriter(new FileWriter(csvPath.toFile()))) {
+
+                                javaFileStream.forEach(javaFile -> {
+                                    FILE_NUM[0] += 1;
+
+                                    System.out.print("\r");
+                                    System.out.print("Parsing : " + javaFile.getFileName());
+
+                                    Resolver resolver = new Resolver(true);
+                                    try {
+                                        CompilationUnit cu = StaticJavaParser.parse(javaFile);
+                                        resolver.execute(cu);
+                                    } catch (IOException e) {
+                                        throw new UncheckedIOException(e);
+                                    } catch (ParseProblemException e) {
+                                        System.out.println("ParseProblemException : " + javaFile.getFileName() + " : "
+                                                + e.getMessage());
+                                        return; // continue to next file
+                                    }
+                                    resolveSuccess[0] += resolver.getResolveSuccess();
+                                    resolveFailed[0] += resolver.getResolveFailed();
+
+                                    for (GraphEdge edge : resolver.getEdges()) {
+                                        String[] line = { edge.source().type(),
+                                                edge.source().name(), edge.type(), edge.target().type(),
+                                                edge.target().name() };
+                                        csvWriter.writeNext(line);
+                                    }
+                                });
+                            } catch (IOException e) {
+                                throw new UncheckedIOException(e);
+                            } finally {
+                                JavaParserFacade.clearInstances();
+                                System.gc();
+                            }
                         }
-
                         totalResolveSuccess[0] += resolveSuccess[0];
                         totalResolveFailed[0] += resolveFailed[0];
                         System.out.println();

--- a/RelationExtractor/src/main/java/Resolver.java
+++ b/RelationExtractor/src/main/java/Resolver.java
@@ -11,6 +11,7 @@ import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.resolution.types.ResolvedReferenceType;
 
 public class Resolver {
     private List<GraphEdge> edges;
@@ -163,8 +164,14 @@ public class Resolver {
         String name = parent.getNameAsString();
         if (doNameResolve) {
             try {
-                name = parent.resolve().getQualifiedName();
-                resolveSuccess++;
+                var resolvedType = parent.resolve();
+                if (resolvedType.isReferenceType()) {
+                    ResolvedReferenceType resolvedReferenceType = resolvedType.asReferenceType();
+                    name = resolvedReferenceType.getQualifiedName();
+                    resolveSuccess++;
+                } else {
+                    resolveFailed ++;
+                }
             } catch (Throwable t) {
                 resolveFailed++;
             }


### PR DESCRIPTION
This pull request addresses the performance issue by updating to the latest version of JavaParser and making necessary adjustments to the code for compatibility with the updated library.

Prior to this update, the RelationExtractor took more than 10 minutes to process a single Java file within the "google__guice" project. With these changes, the processing time has significantly reduced to under 3 minutes for the entire google__guice project, as tested in my environment.